### PR TITLE
Scope dependency-graph submission to exclude the buildscript classpath

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -266,7 +266,20 @@ jobs:
           distribution: temurin
           java-version: 17
 
-      # Resolves the full build dependency graph and submits it to the GitHub
+      # Resolves the build dependency graph and submits it to the GitHub
       # Dependency Graph API. Same gradle/actions release SHA the CI workflow pins
       # for setup-gradle (v6.2.0) — dependency-submission ships from the same repo.
+      #
+      # DEPENDENCY_GRAPH_EXCLUDE_CONFIGURATIONS drops the buildscript `classpath`
+      # configuration from the submitted graph. That configuration is where the
+      # Android Gradle Plugin and its transitive build-time tooling live (apksig →
+      # BouncyCastle, the Google API/analytics client → Netty/jose4j/httpclient,
+      # jdom2, OpenTelemetry). Those run only on the build machine and never ship in
+      # the APK or the iOS app, yet Dependabot was raising ~36 alerts against them
+      # rooted at settings.gradle.kts — noise we can't remediate independently (they
+      # are pinned by AGP). The regex is anchored (`^classpath$`) so it excludes only
+      # the buildscript classpath configs, never the app's `*RuntimeClasspath`
+      # configurations that carry dependencies we actually ship.
       - uses: gradle/actions/dependency-submission@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+        env:
+          DEPENDENCY_GRAPH_EXCLUDE_CONFIGURATIONS: "^classpath$"


### PR DESCRIPTION
## Summary

Stops Dependabot from raising ~36 unactionable alerts (1 critical, 14 high) against the **Android Gradle Plugin's build-time transitive dependencies**, which are never shipped in the app.

## Background

The `dependency-submission` job submits the full resolved Gradle graph. That graph included the root buildscript `classpath` configuration — where AGP 9.2.1 and its build tooling live: apksig→BouncyCastle, the Google API/analytics client→Netty/jose4j/httpclient, jdom2, OpenTelemetry, commons-lang3. GitHub rooted all of them at `settings.gradle.kts` and Dependabot alerted on each. They:

- run only on the build machine and **never ship** in the APK or iOS app, and
- are **transitively pinned by AGP** — we declare none of them and can't bump them independently; they clear when AGP does.

`./gradlew buildEnvironment` confirms all 36 flagged packages resolve through the `classpath` configuration.

## Change

Set `DEPENDENCY_GRAPH_EXCLUDE_CONFIGURATIONS="^classpath$"` on the `gradle/actions/dependency-submission` step. The anchored regex drops only the buildscript `classpath` configs; the app's `*RuntimeClasspath` configs (dependencies we actually ship) are still submitted. On the next push to `main`, GitHub re-submits the narrowed graph and auto-dismisses the stale build-time alerts.

## Test plan

- [ ] After merge to `main`, the `dependency-submission` job runs and the ~36 AGP-classpath alerts auto-dismiss in the Security tab
- [ ] Any genuine app/runtime dependency (when the data layer lands) still appears in the graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)