### PR TITLE
Add release signing for the Android app and prepare the next version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,5 @@ fastlane/test_output
 # After new code Injection tools there's a generated folder /iOSInjectionProject
 # https://github.com/johnno1962/injectionforxcode
 iOSInjectionProject/
+# Release signing credentials — points at a keystore outside the repo. Never committed.
+keystore.properties

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -199,7 +199,7 @@ android {
         applicationId = "io.jitrapon.astro"
         minSdk = 23
         targetSdk = 37
-        versionCode = 2
+        versionCode = 3
         versionName = "0.1.1"
         vectorDrawables { useSupportLibrary = true }
     }

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -3,6 +3,7 @@ import com.ncorti.ktfmt.gradle.FormattingOptionsBean
 import com.ncorti.ktfmt.gradle.KtfmtExtension
 import com.ncorti.ktfmt.gradle.tasks.KtfmtCheckTask
 import com.ncorti.ktfmt.gradle.tasks.KtfmtFormatTask
+import java.util.Properties
 
 plugins {
     id("com.android.application")
@@ -161,6 +162,36 @@ afterEvaluate {
     }
 }
 
+// Release signing credentials. Read from a gitignored `keystore.properties` at the repo root, or
+// from the matching environment variables when that file is absent (CI, a fresh clone). The
+// keystore itself lives outside the repo — `storeFile` is an absolute path into it — so no secret
+// and no key material is ever tracked by git.
+//
+// Resolution is deliberately all-or-nothing: unless every one of the four values is present the
+// release build stays unsigned, exactly as it was before signing existed. That is what keeps
+// CI green — the `verify-android-common` job runs `:androidApp:assemble`, which builds the release
+// variant on a runner that has no keystore, and a half-configured signingConfig would fail it at
+// configuration time rather than skip.
+val keystorePropertiesFile = rootProject.file("keystore.properties")
+val keystoreProperties =
+    Properties().apply {
+        if (keystorePropertiesFile.exists()) {
+            keystorePropertiesFile.inputStream().use(::load)
+        }
+    }
+
+fun resolveSigningCredential(propertyKey: String, environmentKey: String): String? =
+    keystoreProperties.getProperty(propertyKey) ?: System.getenv(environmentKey)
+
+val releaseStoreFile = resolveSigningCredential("storeFile", "ASTRO_KEYSTORE_FILE")
+val releaseStorePassword = resolveSigningCredential("storePassword", "ASTRO_KEYSTORE_PASSWORD")
+val releaseKeyAlias = resolveSigningCredential("keyAlias", "ASTRO_KEY_ALIAS")
+val releaseKeyPassword = resolveSigningCredential("keyPassword", "ASTRO_KEY_PASSWORD")
+val hasReleaseSigningCredentials =
+    listOf(releaseStoreFile, releaseStorePassword, releaseKeyAlias, releaseKeyPassword).none {
+        it.isNullOrBlank()
+    }
+
 android {
     compileSdk = 37
 
@@ -173,7 +204,25 @@ android {
         vectorDrawables { useSupportLibrary = true }
     }
 
-    buildTypes { getByName("release") { isMinifyEnabled = true } }
+    signingConfigs {
+        if (hasReleaseSigningCredentials) {
+            create("release") {
+                storeFile = file(releaseStoreFile!!)
+                storePassword = releaseStorePassword
+                keyAlias = releaseKeyAlias
+                keyPassword = releaseKeyPassword
+            }
+        }
+    }
+
+    buildTypes {
+        getByName("release") {
+            isMinifyEnabled = true
+            // Null when no credentials resolved, which leaves the variant unsigned rather than
+            // failing the build — see the all-or-nothing note above `keystorePropertiesFile`.
+            signingConfig = signingConfigs.findByName("release")
+        }
+    }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -199,8 +199,8 @@ android {
         applicationId = "io.jitrapon.astro"
         minSdk = 23
         targetSdk = 37
-        versionCode = 3
-        versionName = "0.1.1"
+        versionCode = 4
+        versionName = "0.1.2"
         vectorDrawables { useSupportLibrary = true }
     }
 


### PR DESCRIPTION
## Why

Google Play sent an `[Action Needed]` inactivity notice on 2026-09-04: the developer account is closed on **2026-11-03** unless contact details are verified and an app or update is published. Answering it needed a signed AAB, and `:androidApp` had no signing config at all — `bundleRelease` produced an unsigned bundle that Play rejects on upload.

This is the third iteration of the same six-month ritual (warnings in Jun 2025, Feb 2026, Sep 2026), so the signing setup is checked in rather than done ad hoc.

## What

**Release signing (`androidApp/build.gradle.kts`).** Credentials resolve from a gitignored `keystore.properties` at the repo root, falling back to `ASTRO_KEYSTORE_FILE` / `ASTRO_KEYSTORE_PASSWORD` / `ASTRO_KEY_ALIAS` / `ASTRO_KEY_PASSWORD`. The keystore stays outside the repo behind an absolute `storeFile` path — no key material and no secret is tracked.

Resolution is **all-or-nothing**: unless all four values are present, no `signingConfig` object is created and `signingConfig` resolves to null, leaving the variant unsigned exactly as before. That is deliberate and load-bearing — `verify-android-common` runs `:androidApp:assemble`, which builds the *release* variant on a runner with no keystore, and a half-configured `signingConfigs { create("release") }` fails at **configuration** time, before any task runs.

**Version bump.** `versionCode` 2 → 4, `versionName` 0.1.1 → 0.1.2. versionCode 3 / 0.1.1 is now published on the internal test track, so both are spent; the checked-in version is the next one a release build can actually upload. `versionName` advances by a patch because this carries build tooling only — no user-facing change.

## Verification

- `./gradlew check` — green.
- Signed AAB built and its signer certificate verified against the registered upload certificate: SHA-256 `F8:ED:EA:AE:CE:53:BB:2C:F8:BA:BF:D6:B7:E3:D1:D2:D3:44:2B:36:B6:B3:31:D7:E4:A3:77:F6:AD:A8:06:98` — exact match. (An AAB carries only a v1 JAR signature, so `keytool -printcert -jarfile` is the check; `apksigner` does not read bundles.)
- Credential-less path re-verified: with no `keystore.properties`, `bundleRelease` still succeeds and emits an unsigned AAB, so CI is unaffected.
- versionCode confirmed from the merged release manifest, not just the build script.
- versionCode 3 / versionName 0.1.1 was uploaded to the internal track.

## Follow-ups (not in this PR)

- Verify contact email + phone on the Play Console **Account details** page — the other half of what Google's notice requires, and unaffected by the release.
- An internal-track release is not reviewed, and Google's first closure criterion targets accounts that have "never submitted an app for review". If the warning recurs, that is the likely reason.
- The repo has no release tags, which is why "what versionName is unreleased?" took a git-archaeology pass to answer. Tagging released commits would make it a one-liner next time.

## Plan Update

```yaml
lane: -
task: -
completes: no
issues: []
deferred: []
spec-objective: Ad-hoc — answer Google Play's account-inactivity notice by making the Android app signable and publishable; no SPEC, no lane, no plan task row.
```

## Test plan

- [x] `./gradlew check` — green at branch HEAD.
- [x] Signed AAB built; signer certificate verified against the registered Play upload certificate (exact SHA-256 match).
- [x] Credential-less build path re-verified — unsigned AAB still builds, so CI is unaffected.

*No adversarial review round was run: this branch was driven ad hoc rather than through `scaffold-issue` → `spec-development`, so it carries no SPEC and no plan task row. `lane: -` means `sync-plan` deliberately reports nothing for it.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UdoeKFeKxRJRPpzyzgS5EK
